### PR TITLE
Implement Google Tag Manager integration with Partytown

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,10 +1,18 @@
 // @ts-check
 import { defineConfig } from 'astro/config';
 import tailwindcss from '@tailwindcss/vite';
+import partytown from '@astrojs/partytown';
 
 // https://astro.build/config
 export default defineConfig({
   vite: {
     plugins: [tailwindcss()],
   },
+  integrations: [
+    partytown({
+      config: {
+        forward: ['dataLayer.push'],
+      },
+    }),
+  ],
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "version": "0.0.1",
       "dependencies": {
         "@astrojs/check": "^0.9.4",
+        "@astrojs/partytown": "^2.1.4",
         "@tailwindcss/vite": "^4.1.11",
         "astro": "^5.12.2",
         "gsap": "^3.13.0",
@@ -126,6 +127,16 @@
         "unist-util-visit": "^5.0.0",
         "unist-util-visit-parents": "^6.0.1",
         "vfile": "^6.0.3"
+      }
+    },
+    "node_modules/@astrojs/partytown": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@astrojs/partytown/-/partytown-2.1.4.tgz",
+      "integrity": "sha512-loUrAu0cGYFDC6dHVRiomdsBJ41VjDYXPA+B3Br51V5hENFgDSOLju86OIj1TvBACcsB22UQV7BlppODDG5gig==",
+      "license": "MIT",
+      "dependencies": {
+        "@qwik.dev/partytown": "^0.11.0",
+        "mrmime": "^2.0.1"
       }
     },
     "node_modules/@astrojs/prism": {
@@ -1153,6 +1164,21 @@
       "resolved": "https://registry.npmjs.org/@oslojs/encoding/-/encoding-1.1.0.tgz",
       "integrity": "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==",
       "license": "MIT"
+    },
+    "node_modules/@qwik.dev/partytown": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/@qwik.dev/partytown/-/partytown-0.11.2.tgz",
+      "integrity": "sha512-795y49CqBiKiwKAD+QBZlzlqEK275hVcazZ7wBPSfgC23L+vWuA7PJmMpgxojOucZHzYi5rAAQ+IP1I3BKVZxw==",
+      "license": "MIT",
+      "dependencies": {
+        "dotenv": "^16.4.7"
+      },
+      "bin": {
+        "partytown": "bin/partytown.cjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
     },
     "node_modules/@rollup/pluginutils": {
       "version": "5.2.0",
@@ -2741,6 +2767,18 @@
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
       "license": "MIT"
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
     },
     "node_modules/dset": {
       "version": "3.1.4",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@astrojs/check": "^0.9.4",
+    "@astrojs/partytown": "^2.1.4",
     "@tailwindcss/vite": "^4.1.11",
     "astro": "^5.12.2",
     "gsap": "^3.13.0",

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -9,14 +9,14 @@ export interface Props {
   xEyes?: boolean;
 }
 
-const { 
-  title, 
+const {
+  title,
   description = "Luke DeWitt - Developer from Halifax, Nova Scotia",
   ogImage = "/images/luke-head.png",
   ogType = "website",
   publishDate,
   layout = "page",
-  xEyes = false
+  xEyes = false,
 } = Astro.props;
 
 const siteURL = Astro.site || "https://www.whatadewitt.com";
@@ -35,6 +35,8 @@ try {
   ogImageURL = siteURL + "/images/luke-head.png";
 }
 
+// Google Tag Manager
+const gtmId = Astro.env?.PUBLIC_GTM_ID || "";
 
 import HomepageLayout from "../components/layouts/HomepageLayout.astro";
 import BlogLayoutContent from "../components/layouts/BlogLayoutContent.astro";
@@ -55,24 +57,83 @@ import "../styles/global.css";
     <meta property="og:type" content={ogType} />
     <meta property="og:url" content={canonicalURL.toString()} />
     <meta property="og:image" content={ogImageURL} />
-    {publishDate && <meta property="article:published_time" content={publishDate} />}
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" />
+    {
+      publishDate && (
+        <meta property="article:published_time" content={publishDate} />
+      )
+    }
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css"
+    />
     <link rel="icon" href="/favicon-32x32.png" type="image/png" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;700;800&display=swap" rel="stylesheet" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;700;800&display=swap"
+      rel="stylesheet"
+    />
     <script is:inline>
-      if (localStorage.getItem('color-theme') === 'dark' || (!('color-theme' in localStorage) && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
-        document.documentElement.classList.add('dark');
+      if (
+        localStorage.getItem("color-theme") === "dark" ||
+        (!("color-theme" in localStorage) &&
+          window.matchMedia("(prefers-color-scheme: dark)").matches)
+      ) {
+        document.documentElement.classList.add("dark");
       }
     </script>
 
-    <!-- Google Tag Manager placeholder -->
+    <!-- Google Tag Manager -->
+    {gtmId && (
+      <script is:inline>
+        window.dataLayer = window.dataLayer || [];
+        window.dataLayer.push({
+          'gtm.start': new Date().getTime(),
+          event: 'gtm.js'
+        });
+      </script>
+      <script type="text/partytown" src={"https://www.googletagmanager.com/gtm.js?id=" + gtmId}></script>
+    )}
   </head>
   <body class="min-h-screen">
-    {layout === "homepage" && <HomepageLayout xEyes={xEyes}><slot name="controls" slot="controls" /><slot /></HomepageLayout>}
-    {layout === "blog" && <BlogLayoutContent><slot name="controls" slot="controls" /><slot /></BlogLayoutContent>}
-    {layout === "page" && <PageLayout><slot name="controls" slot="controls" /><slot /></PageLayout>}
+    <!-- Google Tag Manager (noscript) -->
+    {gtmId && (
+      <noscript>
+        <iframe src={"https://www.googletagmanager.com/ns.html?id=" + gtmId}
+          height="0" width="0" style="display:none;visibility:hidden"></iframe>
+      </noscript>
+    )}
+
+    {
+      layout === "homepage" && (
+        <HomepageLayout xEyes={xEyes}>
+          <>
+            <slot name="controls" slot="controls" />
+            <slot />
+          </>
+        </HomepageLayout>
+      )
+    }
+    {
+      layout === "blog" && (
+        <BlogLayoutContent>
+          <>
+            <slot name="controls" slot="controls" />
+            <slot />
+          </>
+        </BlogLayoutContent>
+      )
+    }
+    {
+      layout === "page" && (
+        <PageLayout>
+          <>
+            <slot name="controls" slot="controls" />
+            <slot />
+          </>
+        </PageLayout>
+      )
+    }
   </body>
 
   <style is:global>
@@ -115,7 +176,9 @@ import "../styles/global.css";
       font-family: var(--font-mono-jetbrains);
       background-color: var(--bg-color);
       color: var(--text-color);
-      transition: background-color 0.3s ease, color 0.3s ease;
+      transition:
+        background-color 0.3s ease,
+        color 0.3s ease;
     }
   </style>
 </html>


### PR DESCRIPTION
- Added @astrojs/partytown integration to astro.config.mjs with dataLayer.push forwarding
- Implemented GTM scripts in BaseLayout.astro using Partytown to avoid script parsing issues
- Uses Astro.env instead of import.meta.env to prevent unterminated string literal errors
- String concatenation instead of template literals for URL construction
- Conditional loading only when PUBLIC_GTM_ID environment variable is set
- Includes both main GTM script (via Partytown) and noscript fallback

Setup: Copy .env.example to .env and set PUBLIC_GTM_ID=GTM-XXXXXXX

🤖 Generated with [Claude Code](https://claude.ai/code)