### PR TITLE
Trim repetitive homepage copy

### DIFF
--- a/src/components/OffTheKeyboard.astro
+++ b/src/components/OffTheKeyboard.astro
@@ -6,13 +6,13 @@ const facets = [
   },
   {
     title: "Conference speaker",
-    body: "— I enjoy giving talks on developer experience, engineering leadership, or anything techy. Planning an event and need a speaker?",
+    body: "— I enjoy giving talks on developer experience, team culture, or anything techy. Planning an event and need a speaker?",
     href: "https://www.linkedin.com/in/lukedewitt/",
     linkText: "book me →",
   },
   {
     title: "Baseball diehard",
-    body: "— the Blue Jays own an unreasonable share of my attention — forever fiddling with my fantasy lineups.",
+    body: "— the Blue Jays own an unreasonable and frankly indefensible share of my attention.",
   },
   {
     title: "Builder of things",

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -10,8 +10,7 @@ import BaseLayout from "../layouts/BaseLayout.astro";
   </h2>
 
   <p class="mt-6 text-stone-600 dark:text-indigo-200 leading-relaxed">
-    I'm a developer based in Halifax, Nova Scotia, and a big "team" guy — I
-    believe that if you're going to lead, you have to do it while keeping your
-    hands dirty.
+    Based in Halifax, Nova Scotia. I'm a big "team" guy — if I'm going to lead,
+    I'd rather do it with my hands on the keyboard than over someone's shoulder.
   </p>
 </BaseLayout>


### PR DESCRIPTION
## Summary

Removes overlapping phrasing across the homepage hero and the `off_the_keyboard` facets so the copy reads fun but not repetitive:

- **Intro** no longer re-states "developer" from the *Director • Developer • Dad* subheading, and now nods to the `off_the_keyboard` section below it.
- **Conference speaker** drops "engineering leadership" so leadership isn't struck three times (intro / speaker / coaching).
- **Baseball diehard** becomes the pure fan note; "fantasy" now lives only in the **Builder of things** facet.

## Verification

- `npm run build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UDQzaXm1C1yg5Bni6A53Ma

---
_Generated by [Claude Code](https://claude.ai/code/session_01UDQzaXm1C1yg5Bni6A53Ma)_